### PR TITLE
Fix links

### DIFF
--- a/_posts/13-pull-requests/2020-06-03-work-in-pr.md
+++ b/_posts/13-pull-requests/2020-06-03-work-in-pr.md
@@ -50,72 +50,72 @@ Complete the following steps to evaluate a PR on GitHub.
 
     For example, in the following image, [the WayPoint Ventures' test repository](https://GitHub.com/WaypointVentures/Testrepo1/) (**Testrepo1**) is open on GitHub.
 
-    ![Example GitHub repo in a web browser](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-001.png)
+    ![Example GitHub repo in a web browser](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-001.png)
 
 2. Choose the **Pull requests** tab, and then select the GitHub PR you require from the list of **open** PRs.
 
-    ![GitHub 'pull requests' tab](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-002.png)
+    ![GitHub 'pull requests' tab](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-002.png)
 
     > **Note**: To view details about a PR that was closed previously, choose the **closed** icon from the **Pull requests** page, and then select the GitHub PR you require from the list of **closed** PRs.
 
 3. Choose the **Files changed** tab.
 
-    ![GitHub 'Files changed' tab](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-003.png)
+    ![GitHub 'Files changed' tab](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-003.png)
 
     > **Note**: The **Files changed** tab shows a list of all the files within the PR that were added or changed by another contributor.
     >
 
 4. Select the **expand arrow** icon, on the left side (beside a filename), to expand or collapse the contents of a file in the PR.
 
-    ![GitHub 'pull requests' tab with expand/ collapse arrows](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-004a.png)
+    ![GitHub 'pull requests' tab with expand/ collapse arrows](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-004a.png)
 
     Inside the file, items that have been replaced or deleted are colored in **red**. Items that have been added are colored in **green**.
 
-    ![File contents in the GitHub editor](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-004b.png)
+    ![File contents in the GitHub editor](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-004b.png)
 
 5. **Optional**: Add a comment to query a proposed change or specific area of a modified file.
 
     To add a comment about a proposed change, hover your cursor over part of the file, then select the **blue box with the white plus sign**. Type your comment, and choose **Start a review**. You can preview your comment from the **Preview** tab.
 
-    ![The 'add comment' field within the 'files changed' tab of a GitHub pull request](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-005a.png)
+    ![The 'add comment' field within the 'files changed' tab of a GitHub pull request](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-005a.png)
 
     > **Note**: Use the **Start a review** feature to create a new *GitHub PR review*. A GitHub PR review is visible to the person proposing the changes, the owner of the originating branch, and any other contributor assigned to the PR. Use the **GitHub PR review** and commenting feature to initiate a discussion among stakeholders about proposed file changes on GitHub. If deeper discussion is necessary, supplement your GitHub review comments with email communication.
     >
 
     Stakeholders can exchange comments in the **Review comment area** by typing into the **reply box**.
 
-    ![The 'reply to comment' text entry field within the files changed tab of a GitHub pull request](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-005b.png)
+    ![The 'reply to comment' text entry field within the files changed tab of a GitHub pull request](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-005b.png)
 
     After you've typed your GitHub PR review comment, select **Add review comment**.
 
-    ![The 'add review comment' button for submitting comments associated with a GitHub pull request](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-005c.png)
+    ![The 'add review comment' button for submitting comments associated with a GitHub pull request](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-005c.png)
 
     > **Note**: You can edit a GitHub PR review comment after it's been posted.
 
 6. To apply a proposed change, open a file for editing by selecting the **ellipsis** icon on the right side of the file (three dots `...`), and select **Edit file**.
 
-    ![The 'edit file' button for launching the GitHub editor](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-006.png)
+    ![The 'edit file' button for launching the GitHub editor](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-006.png)
 
 7. Apply changes to the file by typing directly into the **GitHub editor** panel.
 
     The GitHub editor allows you to scroll through a file's contents, make edits, and preview changes in your browser.
 
-    ![GitHub editor with a file open for editing](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-007.png)
+    ![GitHub editor with a file open for editing](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-007.png)
 
 8. When you've applied your changes, scroll to the end of the **GitHub editor** panel. Enter a short title and description for your changes. Ensure that the option to **commit directly to the reviewer branch** is selected, and choose **Commit changes**.
 
-    ![GitHub editor 'commit changes' button](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-008a.png)
+    ![GitHub editor 'commit changes' button](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-008a.png)
 
     The change you made is visible inside the **GitHub editor** panel. Your commit will be added to the GitHub PR that's open on the current branch.
 
-    ![GitHub editor with changes made to an opened file](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-008b.png)
+    ![GitHub editor with changes made to an opened file](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-008b.png)
 
     > **Note**: Alternatively, you can choose to commit your edits to a new branch, and then open a new PR to request merging your edits into the originating branch.
     >
 
 9. When you've evaluated and applied your changes to a file, set the file's status to **Viewed** using the checkbox, as shown in the following image.
 
-    ![File status checkbox set to 'viewed' on GitHub](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-009.png)
+    ![File status checkbox set to 'viewed' on GitHub](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-009.png)
 
     > **Note**: Setting a file's status to **Viewed** indicates that the file has been evaluated, and can proceed to the next stage in the process. Updating a file's status allows other contributors to track the progress of a review from the corresponding GitHub PR page.
     >
@@ -124,17 +124,17 @@ Complete the following steps to evaluate a PR on GitHub.
 
     GitHub's **rich diff** (rich differences) feature provides a preview of the file changes that a PR contains, like the **Track Changes** option in Microsoft Word.
 
-    ![Output of GitHub's 'rich diff' for previewing the file changes](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-010a.png)
+    ![Output of GitHub's 'rich diff' for previewing the file changes](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-010a.png)
 
     To return to the default diff view, select the **Display the source diff** icon again.
 
-    ![The 'Display the source diff' button on GitHub](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-010b.png)
+    ![The 'Display the source diff' button on GitHub](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-010b.png)
 
 11. Other contributors to the PR can evaluate file changes, and add comments.
 
     Contributors can add and submit comments and emoji's (optional) from the **Conversation** tab, to discuss proposed changes.
 
-    ![The 'Conversation' tab within a GitHub PR](../assets/images/13-pull-requests/work-pr/GitHub/pr-evaluate-011.png)
+    ![The 'Conversation' tab within a GitHub PR](../assets/images/13-pull-requests/work-pr/github/pr-evaluate-011.png)
 
 12. Work through the GitHub PR until you have reviewed and implemented all the necessary file changes.
 

--- a/_posts/17-appendices/2020-06-02-faq.md
+++ b/_posts/17-appendices/2020-06-02-faq.md
@@ -14,94 +14,94 @@ video_url: "none"
 
 faq:
     - question: Where do I start?
-      answer: Guides that are essential to contributing content are collated on a single page in the [Quick Start](/quickstart/quickstart.html). Alternatively, choose a specific topic from the left sidebar menu. For example, there are guides in the section **Workflow and processes** that describe the *General workflow*, *Authoring process*, *Technical reviews*, *Instructional design reviews*, *Content editing*, and *Testing*. Beginning contributors should follow the guides in the section [Install software](/install/install-vsc.html), and then move on to the guides in the section [Workflow and processes](/workflow/terminology.html).
+      answer: Guides that are essential to contributing content are collated on a single page in the [Quick Start](../quickstart/quickstart.html). Alternatively, choose a specific topic from the left sidebar menu. For example, there are guides in the section **Workflow and processes** that describe the *General workflow*, *Authoring process*, *Technical reviews*, *Instructional design reviews*, *Content editing*, and *Testing*. Beginning contributors should follow the guides in the section [Install software](../install/install-vsc.html), and then move on to the guides in the section [Workflow and processes](../workflow/terminology.html).
 
     - question: Do I need to install software?
-      answer: Yes. Most contributors *must* install software by following the guides in the section [Install software](/install/install-vsc.html). To *view* the course files on GitHub or AzRepos, without installing software, follow the guide [View course files in web browser](/download-files/view-in-browser.html). If your project requires converting markdown files into Microsoft Word documents, install the software tools for converting files by following the guides in the section [Prepublication preparations](/pre-pub/prepub-about.html).
+      answer: Yes. Most contributors *must* install software by following the guides in the section [Install software](../install/install-vsc.html). To *view* the course files on GitHub or AzRepos, without installing software, follow the guide [View course files in web browser](../download-files/view-in-browser.html). If your project requires converting markdown files into Microsoft Word documents, install the software tools for converting files by following the guides in the section [Prepublication preparations](../pre-pub/prepub-about.html).
 
     - question: Where are the markdown files for my project?
-      answer: Ask your project manager where the files for the project you're working on are stored, and how to access them. The files for most projects will be stored on GitHub, AzRepos, Teams, or SharePoint. To *view* markdown files on GitHub or AzRepos, without installing software, follow the guide [View course files in web browser](/download-files/view-in-browser.html). To edit or add content to files from GitHub or AzRepos, follow the guides in the section [Install software](/install/install-vsc.html), and then download (clone) the files from GitHub or AzRepos by following the guide [Download course files (clone repo)](/download-files/clone-repo.html).
+      answer: Ask your project manager where the files for the project you're working on are stored, and how to access them. The files for most projects will be stored on GitHub, AzRepos, Teams, or SharePoint. To *view* markdown files on GitHub or AzRepos, without installing software, follow the guide [View course files in web browser](../download-files/view-in-browser.html). To edit or add content to files from GitHub or AzRepos, follow the guides in the section [Install software](../install/install-vsc.html), and then download (clone) the files from GitHub or AzRepos by following the guide [Download course files (clone repo)](../download-files/clone-repo.html).
 
     - question: What are Git, GitHub, and AzRepos?
-      answer: Git is system of software tools for compartmentalizing a set of files into a unit called a "repo" (short for **repository**). Git implements version control by tracking the changes you make to each file in a repo, and Git can create and manage multiple repos. GitHub is a web service for hosting and sharing remote (public and private) repos. AzRepos is short for **Azure Repos**. AzRepos is a web service for hosting and sharing remote private repos. Terms and concepts, including *Git*, *GitHub*, and *AzRepos*, are explained in the guide [Terminology and concepts](/workflow/terminology.html), and in the [Glossary](/appendices/glossary.html).
+      answer: Git is system of software tools for compartmentalizing a set of files into a unit called a "repo" (short for **repository**). Git implements version control by tracking the changes you make to each file in a repo, and Git can create and manage multiple repos. GitHub is a web service for hosting and sharing remote (public and private) repos. AzRepos is short for **Azure Repos**. AzRepos is a web service for hosting and sharing remote private repos. Terms and concepts, including *Git*, *GitHub*, and *AzRepos*, are explained in the guide [Terminology and concepts](../workflow/terminology.html), and in the [Glossary](./glossary.html).
 
     - question: What is a repo, a local repo, and a remote repo?
-      answer: Git allows you to compartmentalize a set of files on your computer into a unit called a "repo" (short for **repository**. For example, the set of files for the course you're working on can be contained within a Git repo. Git implements version control by tracking the changes you make to each file in a repo. Terms and concepts, including *repo*, are explained in the guide [Terminology and concepts](/workflow/terminology.html), and in the [Glossary](/appendices/glossary.html). A repo on your computer or network is called a **local repo**. A repo on another computer, like on GitHub's servers, is called a **remote repo**.
+      answer: Git allows you to compartmentalize a set of files on your computer into a unit called a "repo" (short for **repository**. For example, the set of files for the course you're working on can be contained within a Git repo. Git implements version control by tracking the changes you make to each file in a repo. Terms and concepts, including *repo*, are explained in the guide [Terminology and concepts](../workflow/terminology.html), and in the [Glossary](./glossary.html). A repo on your computer or network is called a **local repo**. A repo on another computer, like on GitHub's servers, is called a **remote repo**.
 
     - question: How can I make a (local) repo?
-      answer: Make a local repo by downloading (cloning) a GitHub or AzRepos repo by following the guide [Download course files (clone repo)](/download-files/clone-repo.html). For more information, refer to the GitHub documentation page [Creating, cloning, and archiving repositories](https://docs.github.com/github/creating-cloning-and-archiving-repositories).
+      answer: Make a local repo by downloading (cloning) a GitHub or AzRepos repo by following the guide [Download course files (clone repo)](../download-files/clone-repo.html). For more information, refer to the GitHub documentation page [Creating, cloning, and archiving repositories](https://docs.github.com/github/creating-cloning-and-archiving-repositories).
 
     - question: How do I download (clone) a repo?
-      answer: To download (clone) a GitHub or AzRepos repo, follow the guide [Download course files (clone repo)](/download-files/clone-repo.html). For more information, refer to the GitHub documentation page [Creating, cloning, and archiving repositories](https://docs.github.com/github/creating-cloning-and-archiving-repositories).
+      answer: To download (clone) a GitHub or AzRepos repo, follow the guide [Download course files (clone repo)](../download-files/clone-repo.html). For more information, refer to the GitHub documentation page [Creating, cloning, and archiving repositories](https://docs.github.com/github/creating-cloning-and-archiving-repositories).
 
     - question: How do I create a new branch?
-      answer: To create a new branch, follow the guide [Create new branch](/branches/new-branch.html).
+      answer: To create a new branch, follow the guide [Create new branch](../branches/new-branch.html).
 
     - question: How do I get the latest files (pull updates) from GitHub or AzRepos?
-      answer: To get (pull) the latest files from GitHub or AzRepos, follow the guide [Update branch (pull)](/branches/pull-updates.html).
+      answer: To get (pull) the latest files from GitHub or AzRepos, follow the guide [Update branch (pull)](../branches/pull-updates.html).
 
     - question: How do I delete a branch?
-      answer: To delete a branch, follow the guide [Delete branch](/branches/delete-branch.html).
+      answer: To delete a branch, follow the guide [Delete branch](../branches/delete-branch.html).
 
     - question: How do I recover a deleted branch?
-      answer: To recover a deleted branch, follow the guide [Recover deleted branch](/branches/recover-branch.html).
+      answer: To recover a deleted branch, follow the guide [Recover deleted branch](../branches/recover-branch.html).
 
     - question: How do I change/ switch between branches?
-      answer: To change/ switch between branches, follow the guide [Switch branches](/branches/switch-branch.html).
+      answer: To change/ switch between branches, follow the guide [Switch branches](../branches/switch-branch.html).
 
     - question: How do I write in markdown?
-      answer: To write in markdown, follow the guide [Add/ edit markdown in VSC](/add-content/edit-in-vsc.html). Make sure that the markdown you write adheres to the markdown syntax described in the guide [Markdown syntax guide](/add-content/syntax.html).
+      answer: To write in markdown, follow the guide [Add/ edit markdown in VSC](../add-content/edit-in-vsc.html). Make sure that the markdown you write adheres to the markdown syntax described in the guide [Markdown syntax guide](../add-content/syntax.html).
 
     - question: How do I create a new markdown file?
-      answer: To create a new markdown file, follow the guide [Create new markdown file in VSC](/add-content/create-file.html).
+      answer: To create a new markdown file, follow the guide [Create new markdown file in VSC](../add-content/create-file.html).
 
     - question: How do I preview the contents of a markdown file?
-      answer: Preview a markdown file in Visual Studio Code (VSC) using the **Open Preview to the Side** icon. Use the **Open Preview to the Side** icon to open a rendered version of your markdown file in a VSC **preview tab**, alongside the VSC **editor tab**. The shortcut keys **CTRL** + **SHIFT** + **M** also toggle VSC **Preview to the Side** mode on and off. To toggle a "full-window” markdown preview on and off, use the shortcut keys **CTRL** + **SHIFT** + **V**. Previewing in VSC is described in the guide [Add/ edit markdown in VSC](/add-content/edit-in-vsc.html). For more information about VSC shortcut keys, refer to [Key Bindings for Visual Studio Code](https://code.visualstudio.com/docs/getstarted/keybindings).
+      answer: Preview a markdown file in Visual Studio Code (VSC) using the **Open Preview to the Side** icon. Use the **Open Preview to the Side** icon to open a rendered version of your markdown file in a VSC **preview tab**, alongside the VSC **editor tab**. The shortcut keys **CTRL** + **SHIFT** + **M** also toggle VSC **Preview to the Side** mode on and off. To toggle a "full-window” markdown preview on and off, use the shortcut keys **CTRL** + **SHIFT** + **V**. Previewing in VSC is described in the guide [Add/ edit markdown in VSC](../add-content/edit-in-vsc.html). For more information about VSC shortcut keys, refer to [Key Bindings for Visual Studio Code](https://code.visualstudio.com/docs/getstarted/keybindings).
 
     - question: How do I add images into a markdown file?
-      answer: To add images into a markdown file, follow the guide [Add/ edit images in VSC](/add-content/add-images.html).
+      answer: To add images into a markdown file, follow the guide [Add/ edit images in VSC](../add-content/add-images.html).
 
     - question: Why is an image missing from the markdown preview?
-      answer: For each image link you add into a markdown file, you *must* upload a corresponding image file (PNG). Upload the image file on the filepath that you specified in the image link text. If necessary, rename your image file according to the filename you specified in the image link text. Most projects use a **designated image storage directory** for image files (**media**). Make sure that the image link text in your markdown file is pointing to the correct image storage directory. Verify that the image file you're linking to is present, and stored in the correct directory. Check that the name of the image file matches the filename used in the image link text. Add images into a markdown file by following the guide [Add/ edit images in VSC](/add-content/add-images.html).
+      answer: For each image link you add into a markdown file, you *must* upload a corresponding image file (PNG). Upload the image file on the filepath that you specified in the image link text. If necessary, rename your image file according to the filename you specified in the image link text. Most projects use a **designated image storage directory** for image files (**media**). Make sure that the image link text in your markdown file is pointing to the correct image storage directory. Verify that the image file you're linking to is present, and stored in the correct directory. Check that the name of the image file matches the filename used in the image link text. Add images into a markdown file by following the guide [Add/ edit images in VSC](../add-content/add-images.html).
 
     - question: How do I add a table into a markdown file?
-      answer: The markdown syntax for adding tables into a markdown file is described in the guide [Markdown syntax guide](/add-content/syntax.html).
+      answer: The markdown syntax for adding tables into a markdown file is described in the guide [Markdown syntax guide](../add-content/syntax.html).
 
     - question: What is linting or linter?
-      answer: Checking that computer programming code and encoded text, like markdown, conforms to the correct syntax is called **linting**. A software tool that performs linting is called a **linter**. Terms and concepts, including *linting* and *linter*, are explained in the guide [Terminology and concepts](/workflow/terminology.html), and in the [Glossary](/appendices/glossary.html).
+      answer: Checking that computer programming code and encoded text, like markdown, conforms to the correct syntax is called **linting**. A software tool that performs linting is called a **linter**. Terms and concepts, including *linting* and *linter*, are explained in the guide [Terminology and concepts](../workflow/terminology.html), and in the [Glossary](./glossary.html).
 
     - question: How do I fix a linting issue?
-      answer: Fix a linting issue by following the guide [Fix linter issues](/add-content/fix-linter.html). 
+      answer: Fix a linting issue by following the guide [Fix linter issues](../add-content/fix-linter.html). 
 
     - question: How do I send (push) my files for review?
-      answer: Send your files for review by following the guide [Send (push) files](/branches/push-files.html). The requirements for sending files for review depend on the type of review you're requesting. The requirements for sending files for review are described in the section **Workflow and processes**. There are guides that describe the *General workflow*, *Authoring process*, *Technical reviews*, *Instructional design reviews*, *Content editing*, and *Testing*.
+      answer: Send your files for review by following the guide [Send (push) files](../branches/push-files.html). The requirements for sending files for review depend on the type of review you're requesting. The requirements for sending files for review are described in the section **Workflow and processes**. There are guides that describe the *General workflow*, *Authoring process*, *Technical reviews*, *Instructional design reviews*, *Content editing*, and *Testing*.
 
     - question: What's a pull request (PR)?
-      answer: A pull request (PR) is a request to approve merging (combining) the contents of one branch into another. For more information about pull requests, refer to the guide [Pull requests overview](/pull-requests/pr-overview.html), and the GitHub documentation page [About pull requests](https://docs.github.com/github/collaborating-with-issues-and-pull-requests/about-pull-requests). Terms and concepts, including *pull request*, are explained in the guide [Terminology and concepts](/workflow/terminology.html), and in the [Glossary](/appendices/glossary.html).
+      answer: A pull request (PR) is a request to approve merging (combining) the contents of one branch into another. For more information about pull requests, refer to the guide [Pull requests overview](../pull-requests/pr-overview.html), and the GitHub documentation page [About pull requests](https://docs.github.com/github/collaborating-with-issues-and-pull-requests/about-pull-requests). Terms and concepts, including *pull request*, are explained in the guide [Terminology and concepts](../workflow/terminology.html), and in the [Glossary](./glossary.html).
 
     - question: How do I create a new pull request?
-      answer: To create a new pull request, follow the guide [Create pull request](/pull-requests/create-pr.html).
+      answer: To create a new pull request, follow the guide [Create pull request](../pull-requests/create-pr.html).
 
     - question: How do I add new file changes to a pull request?
-      answer: When you create a pull request (PR), keep the PR open (don't merge the PR). Keeping the PR open allows you to push subsequent file changes from your local branch “up” to GitHub or AzRepos. Any additional changes that you push from your local branch will be “rolled into” your open PR. For more information about pull requests, refer to the guide [Pull requests overview](/pull-requests/pr-overview.html).
+      answer: When you create a pull request (PR), keep the PR open (don't merge the PR). Keeping the PR open allows you to push subsequent file changes from your local branch “up” to GitHub or AzRepos. Any additional changes that you push from your local branch will be “rolled into” your open PR. For more information about pull requests, refer to the guide [Pull requests overview](../pull-requests/pr-overview.html).
 
     - question: How do I merge a pull request?
-      answer: To merge a pull request, follow the guide [Merge a pull request](/pull-requests/merge-pr.html).
+      answer: To merge a pull request, follow the guide [Merge a pull request](../pull-requests/merge-pr.html).
 
     - question: What is a merge conflict?
-      answer: A merge conflict is an error caused by attempts to merge branches that contain incompatible versions of the same file. To fix merge conflicts, follow the guide [Resolve merge conflicts](/pull-requests/merge-conflicts.html). Terms and concepts, including *merge conflict*, are explained in the guide [Terminology and concepts](/workflow/terminology.html), and in the [Glossary](/appendices/glossary.html)
+      answer: A merge conflict is an error caused by attempts to merge branches that contain incompatible versions of the same file. To fix merge conflicts, follow the guide [Resolve merge conflicts](../pull-requests/merge-conflicts.html). Terms and concepts, including *merge conflict*, are explained in the guide [Terminology and concepts](../workflow/terminology.html), and in the [Glossary](./glossary.html)
 
     - question: How do I fix merge errors/ conflicts?
-      answer: To fix merge errors/ conflicts, follow the guide [Resolve merge conflicts](/pull-requests/merge-conflicts.html).
+      answer: To fix merge errors/ conflicts, follow the guide [Resolve merge conflicts](../pull-requests/merge-conflicts.html).
 
     - question: How do I convert a markdown file into a Microsoft Word document?
-      answer: To convert a markdown file into a Microsoft Word document, follow the guide [Convert markdown to doc](/pre-pub/pdoc-convert.html).
+      answer: To convert a markdown file into a Microsoft Word document, follow the guide [Convert markdown to doc](../pre-pub/pdoc-convert.html).
 
     - question: Do I need to install software to convert a markdown file into a Microsoft Word document?
-      answer: Yes. Install the required software tools by following the guide [Setup file conversion tools](/pre-pub/setup-tools.html).
+      answer: Yes. Install the required software tools by following the guide [Setup file conversion tools](../pre-pub/setup-tools.html).
 
     - question: Where can I get more help?
-      answer: Check the links in the guide [Links to useful resources](/appendices/useful-links.html), or ask your project manager for help.
+      answer: Check the links in the guide [Links to useful resources](./useful-links.html), or ask your project manager for help.
 ---
 
 This guide answers some of the most frequently asked questions (FAQ) that contributors have about developing course content.


### PR DESCRIPTION
- Repair broken image links in **Work in PR guide** to fix issue #16 by applying lowercasing `/GitHub/ ` in image link text.
- Repair broken links to internal posts in **FAQ** to fix issue #12 by adding dir switch `../` to links in front matter.