### PR TITLE
Add base URL to quickstart link fix #19

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ sections: [['quickstart','Quick start'],['install','Install software'],['workflo
 
 # Keep as an empty string if served up at the root. If served up at a specific
 # path (e.g. on GitHub pages) leave off the trailing slash, e.g. /my-project
-#baseurl: '/docs'
+baseurl: '/docs-v2-DEV'
 
 # Dates are not included in permalinks
 permalink: none

--- a/_includes/quickstart-builder.html
+++ b/_includes/quickstart-builder.html
@@ -17,7 +17,7 @@
         {% if post.include-in-quickstart != "false" %}
         {% assign counter = counter | plus: 1 %}
         <li>
-            <a href="{{site.baseurl}}{{ quickstart/quickstart.html }}#guide{{ counter }}">{{ post.title }}</a>
+            <a href="{{site.baseurl}}/quickstart/quickstart.html#guide{{counter}}">{{ post.title }}</a>
         </li>
         {% endif%}
         {% endfor %}
@@ -36,11 +36,10 @@
         | remove: incl-vid
         | remove: incl-pag
         | remove: incl-apn
-        | remove: site-base
+        | replace: site-base, "/docs-v2-DEV"
         | markdownify
     }}</div>
     <hr>
     {% endif%}
     {% endfor %}
 </div>
-


### PR DESCRIPTION
Add base URL for GitHub into post **quickstart** to repair broken links and fix #19