### PR TITLE
Add 'AzDevOps' quickstart builder

### DIFF
--- a/_data/map.yml
+++ b/_data/map.yml
@@ -28,8 +28,8 @@
   AzDev: azdev/_posts/07-download-files/2020-06-01-az-view-in-browser.md
 -
   # download files > clone repo
-  GitHub: _posts/07-download-files/2020-06-02-clone-repo.md
-  AzDev: azdev/_posts/07-download-files/2020-06-02-az-clone-repo.md
+  GitHub: _posts/07-download-files/2020-06-03-clone-repo.md
+  AzDev: azdev/_posts/07-download-files/2020-06-03-az-clone-repo.md
 -
   # branches > delete branch
   GitHub: _posts/09-branches/2020-06-07-delete-branch.md

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,11 +1,17 @@
 <div id="breadcrumbs">
 	{% assign crumbs = page.url | remove:'/index.html' | split: '/' %}
-	
 	<a href="{{site.baseurl}}/">Home</a>
-		{% for crumb in crumbs offset: 1 %}
-  			{% if forloop.last %}
-			/ {{ page.category | capitalize }}
-			/ {{ page.title }}
-    		{% endif %}
-    	{% endfor %}
+	{% for crumb in crumbs offset: 1 %}
+	{% if page.lang == "GitHub" %}
+		{% if forloop.last %}
+		/ {{ page.category | capitalize }}
+		/ {{ page.title }}
+	    {% endif %}
+	{% else %}
+		{% if forloop.last %}
+		/ AzDevOps
+		/ {{ page.title }}
+	    {% endif %}
+	{% endif %}
+    {% endfor %}
 </div>

--- a/_includes/quickstart-builder-azdevops.html
+++ b/_includes/quickstart-builder-azdevops.html
@@ -1,0 +1,45 @@
+<div id="az-quickstart-builder">
+    {% assign counter = 0 %}
+    {% assign counter1 = 0 %}
+    {% assign lbrace-pcent = "{%" %}
+    {% assign pcent = '%' %}
+    {% assign rbrace = '}' %}
+    {% assign pcent-rbrace = pcent | append: rbrace %}
+    {% assign incl-pre = " include prerequisites.html" %}
+    {% assign incl-vid = " include video.html" %}
+    {% assign incl-pag = " include paginator.html" %}
+    {% assign incl-apn = " include appendices.html" %}
+    {% assign site-base = "{{site.baseurl}}" %}
+    <h2>Guides in this quick start</h2>
+    <p>This quick start includes the following guides:</p>
+    <ol>
+        {% assign ordered-posts = site.posts | where: 'include-in-azdevops-quickstart', "true" | sort: 'post-number' %}
+        {% for post in ordered-posts %}
+        {% assign counter = counter | plus: 1 %}
+        <li>
+            <a href="{{site.baseurl}}/azdev/az-quickstart.html#guide{{counter}}">{{ post.title }}</a>
+        </li>
+        {% endfor %}
+    </ol>
+</div>
+<div id="az-single-guide">
+    {% assign sorted-posts = site.posts | where: 'include-in-azdevops-quickstart', "true" | sort: 'post-number' %}
+    {% for post in sorted-posts %}
+    {% assign counter1 = counter1 | plus: 1 %}
+    <h1 id="guide{{ counter1 }}">{{ counter1 }}: {{ post.title }}</h1>
+    <div>{{
+        post.content
+        | replace: 'div id="prerequisites"', 'div id="prerequisites" style="display: none;"'
+        | replace: 'div id="appendices"', 'div id="appendices" style="display: none;"'
+        | replace: 'div class="paginator"', 'div class="paginator" style="display: none;"'
+        | remove: lbrace-pcent
+        | remove: pcent-rbrace
+        | remove: incl-pre
+        | remove: incl-vid
+        | remove: incl-pag
+        | remove: incl-apn
+        | replace: site-base, "/docs-v2-DEV"
+        | markdownify
+    }}</div>
+    {% endfor %}
+</div>

--- a/_posts/01-quickstart/2020-06-01-quickstart.md
+++ b/_posts/01-quickstart/2020-06-01-quickstart.md
@@ -2,14 +2,15 @@
 layout: multi
 title: Quick start
 subtitle: GitHub
-description:
-author:
+description: A collection of guides, on a single page, that are essential to contributing content on GitHub
+author: mkavana
 date: 01 Jun 2020
 post-number: 1.1
 category: quickstart
 position-in-category: 1
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "https://web.microsoftstream.com/embed/video/437d4b4b-4aec-41ef-a91f-1ae97a1fcd4e?autoplay=false&amp;showinfo=true"
 ---
 

--- a/_posts/03-install/2020-06-01-install-vsc.md
+++ b/_posts/03-install/2020-06-01-install-vsc.md
@@ -10,6 +10,7 @@ category: install
 position-in-category: 1
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/03-install/2020-06-02-install-author-pack.md
+++ b/_posts/03-install/2020-06-02-install-author-pack.md
@@ -10,6 +10,7 @@ category: install
 position-in-category: 2
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/03-install/2020-06-03-install-wordcount-ext.md
+++ b/_posts/03-install/2020-06-03-install-wordcount-ext.md
@@ -10,6 +10,7 @@ category: install
 position-in-category: 3
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/03-install/2020-06-04-install-pr-ext.md
+++ b/_posts/03-install/2020-06-04-install-pr-ext.md
@@ -10,6 +10,7 @@ category: install
 position-in-category: 4
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/03-install/2020-06-05-install-azrepo-ext.md
+++ b/_posts/03-install/2020-06-05-install-azrepo-ext.md
@@ -9,7 +9,8 @@ post-number: 3.5
 category: install
 position-in-category: 5
 include-in-pre-reqs: "true"
-include-in-quickstart: "true"
+include-in-quickstart: "false"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/03-install/2020-06-06-install-git-history-ext.md
+++ b/_posts/03-install/2020-06-06-install-git-history-ext.md
@@ -8,8 +8,9 @@ date: 01 Jun 2020
 post-number: 3.6
 category: install
 position-in-category: 6
-include-in-pre-reqs: "true"
-include-in-quickstart: "true"
+include-in-pre-reqs: "false"
+include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/03-install/2020-06-07-install-scm-git.md
+++ b/_posts/03-install/2020-06-07-install-scm-git.md
@@ -10,6 +10,7 @@ category: install
 position-in-category: 7
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/03-install/2020-06-08-set-git-credentials.md
+++ b/_posts/03-install/2020-06-08-set-git-credentials.md
@@ -10,6 +10,7 @@ category: install
 position-in-category: 8
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/05-workflow/2020-06-01-terminology.md
+++ b/_posts/05-workflow/2020-06-01-terminology.md
@@ -8,10 +8,10 @@ date: 01 Jun 2020
 post-number: 5.1
 category: workflow
 position-in-category: 1
-include-in-pre-reqs: "false"
+include-in-pre-reqs: "true"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
-#video_url: "https://web.microsoftstream.com/embed/video/eab2fdaf-337d-4ea4-a30f-7301482a34fd"
 ---
 
 This guide explains the key technologies, terms and concepts that are relevant to the content development and review processes described throughout this website.

--- a/_posts/05-workflow/2020-06-02-general-workflow.md
+++ b/_posts/05-workflow/2020-06-02-general-workflow.md
@@ -10,6 +10,7 @@ category: workflow
 position-in-category: 2
 include-in-pre-reqs: "true"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "https://web.microsoftstream.com/embed/video/eab2fdaf-337d-4ea4-a30f-7301482a34fd?autoplay=false&amp;showinfo=true"
 ---
 

--- a/_posts/05-workflow/2020-06-03-author-process.md
+++ b/_posts/05-workflow/2020-06-03-author-process.md
@@ -10,6 +10,7 @@ category: workflow
 position-in-category: 3
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/05-workflow/2020-06-04-tr-process.md
+++ b/_posts/05-workflow/2020-06-04-tr-process.md
@@ -10,6 +10,7 @@ category: workflow
 position-in-category: 4
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/05-workflow/2020-06-05-id-process.md
+++ b/_posts/05-workflow/2020-06-05-id-process.md
@@ -10,6 +10,7 @@ category: workflow
 position-in-category: 5
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/05-workflow/2020-06-06-ce-process.md
+++ b/_posts/05-workflow/2020-06-06-ce-process.md
@@ -10,6 +10,7 @@ category: workflow
 position-in-category: 6
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 <!--todo:

--- a/_posts/05-workflow/2020-06-07-test-process.md
+++ b/_posts/05-workflow/2020-06-07-test-process.md
@@ -10,6 +10,7 @@ category: workflow
 position-in-category: 7
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/07-download-files/2020-06-01-view-in-browser.md
+++ b/_posts/07-download-files/2020-06-01-view-in-browser.md
@@ -10,6 +10,7 @@ category: download-files
 position-in-category: 1
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/07-download-files/2020-06-02-fork-repo.md
+++ b/_posts/07-download-files/2020-06-02-fork-repo.md
@@ -10,6 +10,7 @@ category: download-files
 position-in-category: 2
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: https://web.microsoftstream.com/embed/video/8ed427c4-ce20-4822-b447-1cf36babfe2f
 ---
 

--- a/_posts/07-download-files/2020-06-03-clone-repo.md
+++ b/_posts/07-download-files/2020-06-03-clone-repo.md
@@ -10,6 +10,7 @@ category: download-files
 position-in-category: 3
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/07-download-files/2020-06-04-clone-error.md
+++ b/_posts/07-download-files/2020-06-04-clone-error.md
@@ -10,6 +10,7 @@ category: download-files
 position-in-category: 4
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/09-branches/2020-06-01-branch-policy.md
+++ b/_posts/09-branches/2020-06-01-branch-policy.md
@@ -8,8 +8,9 @@ date: 01 Jun 2020
 post-number: 9.1
 category: branches
 position-in-category: 1
-include-in-pre-reqs: "false"
+include-in-pre-reqs: "True"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/09-branches/2020-06-02-new-branch.md
+++ b/_posts/09-branches/2020-06-02-new-branch.md
@@ -10,6 +10,7 @@ category: branches
 position-in-category: 2
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/09-branches/2020-06-03-pull-updates.md
+++ b/_posts/09-branches/2020-06-03-pull-updates.md
@@ -10,6 +10,7 @@ category: branches
 position-in-category: 3
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/09-branches/2020-06-04-switch-branch.md
+++ b/_posts/09-branches/2020-06-04-switch-branch.md
@@ -10,6 +10,7 @@ category: branches
 position-in-category: 4
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/09-branches/2020-06-05-push-files.md
+++ b/_posts/09-branches/2020-06-05-push-files.md
@@ -10,6 +10,7 @@ category: branches
 position-in-category: 5
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/09-branches/2020-06-06-rename-branch.md
+++ b/_posts/09-branches/2020-06-06-rename-branch.md
@@ -10,6 +10,7 @@ category: branches
 position-in-category: 6
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/09-branches/2020-06-07-delete-branch.md
+++ b/_posts/09-branches/2020-06-07-delete-branch.md
@@ -10,6 +10,7 @@ category: branches
 position-in-category: 7
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/09-branches/2020-06-08-recover-branch.md
+++ b/_posts/09-branches/2020-06-08-recover-branch.md
@@ -10,6 +10,7 @@ category: branches
 position-in-category: 8
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/11-add-content/2020-06-01-syntax.md
+++ b/_posts/11-add-content/2020-06-01-syntax.md
@@ -10,6 +10,7 @@ category: add-content
 position-in-category: 1
 include-in-pre-reqs: "true"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "https://web.microsoftstream.com/embed/video/5db24b49-196a-4971-a48e-a166be26db6f?autoplay=false&amp;showinfo=true"
 ---
 

--- a/_posts/11-add-content/2020-06-02-edit-in-browser.md
+++ b/_posts/11-add-content/2020-06-02-edit-in-browser.md
@@ -10,6 +10,7 @@ category: add-content
 position-in-category: 2
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/11-add-content/2020-06-03-edit-in-vsc.md
+++ b/_posts/11-add-content/2020-06-03-edit-in-vsc.md
@@ -10,6 +10,7 @@ category: add-content
 position-in-category: 3
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/11-add-content/2020-06-04-add-images.md
+++ b/_posts/11-add-content/2020-06-04-add-images.md
@@ -10,6 +10,7 @@ category: add-content
 position-in-category: 4
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/_posts/11-add-content/2020-06-05-create-file.md
+++ b/_posts/11-add-content/2020-06-05-create-file.md
@@ -10,6 +10,7 @@ category: add-content
 position-in-category: 5
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/11-add-content/2020-06-06-author-outline.md
+++ b/_posts/11-add-content/2020-06-06-author-outline.md
@@ -10,6 +10,7 @@ category: add-content
 position-in-category: 6
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/11-add-content/2020-06-07-fix-linter.md
+++ b/_posts/11-add-content/2020-06-07-fix-linter.md
@@ -8,8 +8,9 @@ date: 01 Jun 2020
 post-number: 11.7
 category: add-content
 position-in-category: 7
-include-in-pre-reqs: "false"
+include-in-pre-reqs: "true"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "https://web.microsoftstream.com/embed/video/6e3c80aa-76ee-46d1-81d8-55d7dadfd106?autoplay=false&amp;showinfo=true"
 ---
 

--- a/_posts/11-add-content/2020-06-08-invite.md
+++ b/_posts/11-add-content/2020-06-08-invite.md
@@ -10,6 +10,7 @@ category: add-content
 position-in-category: 8
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/13-pull-requests/2020-06-01-pr-overview.md
+++ b/_posts/13-pull-requests/2020-06-01-pr-overview.md
@@ -10,6 +10,7 @@ category: pull-requests
 position-in-category: 1
 include-in-pre-reqs: "true"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/13-pull-requests/2020-06-02-create-pr.md
+++ b/_posts/13-pull-requests/2020-06-02-create-pr.md
@@ -10,6 +10,7 @@ category: pull-requests
 position-in-category: 2
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/13-pull-requests/2020-06-03-work-in-pr.md
+++ b/_posts/13-pull-requests/2020-06-03-work-in-pr.md
@@ -10,6 +10,7 @@ category: pull-requests
 position-in-category: 3
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/13-pull-requests/2020-06-04-merge-pr.md
+++ b/_posts/13-pull-requests/2020-06-04-merge-pr.md
@@ -10,6 +10,7 @@ category: pull-requests
 position-in-category: 4
 include-in-pre-reqs: "true"
 include-in-quickstart: "true"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/13-pull-requests/2020-06-05-merge-conflicts.md
+++ b/_posts/13-pull-requests/2020-06-05-merge-conflicts.md
@@ -8,8 +8,9 @@ date: 01 Jun 2020
 post-number: 13.5
 category: pull-requests
 position-in-category: 5
-include-in-pre-reqs: "false"
+include-in-pre-reqs: "true"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/15-pre-pub/2020-06-01-prepub-about.md
+++ b/_posts/15-pre-pub/2020-06-01-prepub-about.md
@@ -10,6 +10,7 @@ category: pre-pub
 position-in-category: 1
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/15-pre-pub/2020-06-02-setup-tools.md
+++ b/_posts/15-pre-pub/2020-06-02-setup-tools.md
@@ -10,12 +10,11 @@ category: pre-pub
 position-in-category: 2
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 
 This guide describes how to download and install Pandoc, and setup additional software tools for converting Markdown files (**\.md**) into Microsoft Word documents (**\.docx**).
-
-<!-- {% include prerequisites.html %} -->
 
 ## Topics in this guide
 

--- a/_posts/15-pre-pub/2020-06-03-pdoc-convert.md
+++ b/_posts/15-pre-pub/2020-06-03-pdoc-convert.md
@@ -10,6 +10,7 @@ category: pre-pub
 position-in-category: 3
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 
@@ -25,8 +26,6 @@ This guide describes how to use the software tools **convert_md_to_docx \.bat** 
 >
 > As part of the conversion process, any images and graphics linked in the markdown file will be embedded into the converted Word documents. Before you begin converting files, copy the corresponding image and graphics directory (**media**) for the markdown files, and paste it into the markdown files directory. Ensure you paste the (**media**) directory on correct filepath, relative to image links in the markdown files.
 >
-
-<!-- {% include prerequisites.html %} -->
 
 ## Topics in this guide
 

--- a/_posts/15-pre-pub/2020-06-04-config-styles.md
+++ b/_posts/15-pre-pub/2020-06-04-config-styles.md
@@ -10,6 +10,7 @@ category: pre-pub
 position-in-category: 4
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 
@@ -19,8 +20,6 @@ This guide describes how to attach the style template file **template \.dotx** t
 >
 > Typically, only the styles **Heading 1**, **2**, **3**, **4**, **5**, and **Hyperlink** are applied by Pandoc during conversion. For all other text content, Pandoc applies the style **Normal/ Paragraph normal**. So, some content must be styled "manually" in Microsoft Word.
 >
-
-<!-- {% include prerequisites.html %} -->
 
 ## Topics in this guide
 

--- a/_posts/15-pre-pub/2020-06-05-style-doc.md
+++ b/_posts/15-pre-pub/2020-06-05-style-doc.md
@@ -10,12 +10,11 @@ category: pre-pub
 position-in-category: 5
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 
 This guide describes how to apply styles to a document in Microsoft Word.
-
-<!-- {% include prerequisites.html %} -->
 
 ## Topics in this guide
 

--- a/_posts/17-appendices/2020-06-01-best-practices.md
+++ b/_posts/17-appendices/2020-06-01-best-practices.md
@@ -10,6 +10,7 @@ category: appendices
 position-in-category: 1
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/_posts/17-appendices/2020-06-02-faq.md
+++ b/_posts/17-appendices/2020-06-02-faq.md
@@ -10,6 +10,7 @@ category: appendices
 position-in-category: 2
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 
 faq:

--- a/_posts/17-appendices/2020-06-03-glossary.md
+++ b/_posts/17-appendices/2020-06-03-glossary.md
@@ -3,13 +3,14 @@ layout: page
 title: Glossary
 subtitle: Appendix C
 description: A collection of definitions to explain the terminology used throughout the WayPoint Ventures documentation website.
-author:
+author: mkavana
 date: 01 Jun 2020
 post-number: 17.3
 category: appendices
 position-in-category: 3
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 
 glossary:

--- a/_posts/17-appendices/2020-06-04-useful-links.md
+++ b/_posts/17-appendices/2020-06-04-useful-links.md
@@ -3,13 +3,14 @@ layout: page
 title: Links to useful resources
 subtitle: Appendix D
 description:
-author:
+author: mkavana
 date: 01 Jun 2020
 post-number: 17.4
 category: appendices
 position-in-category: 4
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/azdev/_posts/01-quickstart/2020-06-01-az-quickstart.md
+++ b/azdev/_posts/01-quickstart/2020-06-01-az-quickstart.md
@@ -2,26 +2,20 @@
 layout: multi
 title: Quick start
 subtitle: AzDevOps
-description:
-author:
+description: A collection of guides, on a single page, that are essential to contributing content on AzDevOps
+author: mkavana
 date: 01 Jun 2020
 post-number: 1.1
 #category: quickstart
 #position-in-category: 1
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "https://web.microsoftstream.com/embed/video/e0424e48-398f-4983-9677-551a98c1f9d2?autoplay=false&showinfo=true"
 ---
 
-<!-- 
-uncomment to add content
-
-This **quick start** provides a collection of guides, on a single page, that are essential to contributing content on Azure DevOps. Use this quick start to learn what's required to "get up and running" quickly. Alternatively, choose a single guide from the left sidebar menu.
-
--->
-
-This guide is currently being developed. Select another guide from the left sidebar menu instead.
+This **quick start** provides a collection of guides, on a single page, that are essential to contributing content on AzDevOps. Use this quick start to learn what's required to "get up and running" quickly. Alternatively, choose a single guide from the left sidebar menu.
 
 {% include video.html %}
 
-<!-- {% include quickstart-builder.html %} -->
+{% include quickstart-builder-azdevops.html %}

--- a/azdev/_posts/05-workflow/2020-06-03-az-author-process.md
+++ b/azdev/_posts/05-workflow/2020-06-03-az-author-process.md
@@ -10,6 +10,7 @@ post-number: 5.3
 #position-in-category: 3
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/azdev/_posts/05-workflow/2020-06-04-az-tr-process.md
+++ b/azdev/_posts/05-workflow/2020-06-04-az-tr-process.md
@@ -10,6 +10,7 @@ post-number: 5.4
 #position-in-category: 4
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: none
 video_url: "https://web.microsoftstream.com/embed/video/5941dc02-6438-46df-98da-49ba94ef4541?autoplay=false&amp;showinfo=true"
 ---

--- a/azdev/_posts/05-workflow/2020-06-05-az-id-process.md
+++ b/azdev/_posts/05-workflow/2020-06-05-az-id-process.md
@@ -10,6 +10,7 @@ post-number: 5.5
 #position-in-category: 5
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "https://web.microsoftstream.com/embed/video/966fc3c7-53f0-4abd-81b8-1b3e1fb6eb69?autoplay=false&amp;showinfo=true"
 ---
 

--- a/azdev/_posts/05-workflow/2020-06-06-az-ce-process.md
+++ b/azdev/_posts/05-workflow/2020-06-06-az-ce-process.md
@@ -10,6 +10,7 @@ post-number: 5.6
 #position-in-category: 6
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/azdev/_posts/05-workflow/2020-06-07-az-test-process.md
+++ b/azdev/_posts/05-workflow/2020-06-07-az-test-process.md
@@ -10,6 +10,7 @@ post-number: 5.7
 #position-in-category: 7
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/azdev/_posts/07-download-files/2020-06-01-az-view-in-browser.md
+++ b/azdev/_posts/07-download-files/2020-06-01-az-view-in-browser.md
@@ -10,6 +10,7 @@ post-number: 7.1
 #position-in-category: 1
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/azdev/_posts/07-download-files/2020-06-03-az-clone-repo.md
+++ b/azdev/_posts/07-download-files/2020-06-03-az-clone-repo.md
@@ -5,11 +5,12 @@ subtitle: AzDevOps
 description: A guide to cloning an AzDevOps repo
 author: mkavana
 date: 01 Jun 2020
-post-number: 7.2
+post-number: 7.3
 #category: download-files
-#position-in-category: 2
+#position-in-category: 3
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "true"
 video_url: "none"
 ---
 

--- a/azdev/_posts/09-branches/2020-06-07-az-delete-branch.md
+++ b/azdev/_posts/09-branches/2020-06-07-az-delete-branch.md
@@ -10,6 +10,7 @@ post-number: 9.7
 #position-in-category: 7
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/azdev/_posts/09-branches/2020-06-08-az-recover-branch.md
+++ b/azdev/_posts/09-branches/2020-06-08-az-recover-branch.md
@@ -10,6 +10,7 @@ post-number: 9.8
 #position-in-category: 8
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/azdev/_posts/11-add-content/2020-06-02-az-edit-in-browser.md
+++ b/azdev/_posts/11-add-content/2020-06-02-az-edit-in-browser.md
@@ -10,6 +10,7 @@ post-number: 11.2
 #position-in-category: 2
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 

--- a/azdev/_posts/13-pull-requests/2020-06-02-az-create-pr.md
+++ b/azdev/_posts/13-pull-requests/2020-06-02-az-create-pr.md
@@ -10,6 +10,7 @@ post-number: 13.2
 #position-in-category: 2
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "true"
 video_url: "https://web.microsoftstream.com/embed/video/76a6d02d-a51e-4c98-b41c-1f0a115eea5e?autoplay=false&amp;showinfo=true"
 ---
 

--- a/azdev/_posts/13-pull-requests/2020-06-03-az-work-in-pr.md
+++ b/azdev/_posts/13-pull-requests/2020-06-03-az-work-in-pr.md
@@ -10,6 +10,7 @@ post-number: 13.3
 #position-in-category: 3
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "true"
 video_url: "https://web.microsoftstream.com/embed/video/60192de2-c0fd-4c2c-82ad-b32bcae65d64?autoplay=false&amp;showinfo=true"
 ---
 

--- a/azdev/_posts/13-pull-requests/2020-06-04-az-merge-pr.md
+++ b/azdev/_posts/13-pull-requests/2020-06-04-az-merge-pr.md
@@ -10,6 +10,7 @@ post-number: 13.4
 #position-in-category: 4
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "true"
 video_url: "https://web.microsoftstream.com/embed/video/3b533444-94f5-46c5-97f8-52d8fca5c81c?autoplay=false&amp;showinfo=true"
 ---
 

--- a/azdev/_posts/13-pull-requests/2020-06-05-az-merge-conflicts.md
+++ b/azdev/_posts/13-pull-requests/2020-06-05-az-merge-conflicts.md
@@ -10,6 +10,7 @@ post-number: 13.5
 #position-in-category: 5
 include-in-pre-reqs: "false"
 include-in-quickstart: "false"
+include-in-azdevops-quickstart: "false"
 video_url: "none"
 ---
 


### PR DESCRIPTION
Add new feature to build the 'Azure DevOps' quick start guide from existing posts automatically.

## Changes

- create new include file **quickstart-builder-azdevops.html**. The file builds out the 'Azure DevOps' quick start guide from existing posts automatically. The quickstart is built from posts where the front matter variable **include-in-azdevops-quickstart** is `true`.
- create new front matter string var **include-in-azdevops-quickstart** and add the new var to all posts. Value for new var can be set to `true` or `false`.
- update include **breadcrumbs** to prefix AzDevOps posts with the string **AzDevOps** to improve site navigation.
- correct **map.yml** to map **GitHub clone repo** post to **AzDevOps clone repo** post. The mapping was broken when new (fork-related) guides where added which incremented front matter var **post-number**.
